### PR TITLE
Feed Time controller explicitly calls user time zone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,8 @@ class ApplicationController < ActionController::Base
   def authorize
     redirect_to root_path, notice: 'Please log in or signup' unless current_user
   end
+
+  def parse_time(time)
+    ActiveSupport::TimeZone.new(current_user.time_zone).parse(time).utc
+  end
 end

--- a/app/controllers/feed_times_controller.rb
+++ b/app/controllers/feed_times_controller.rb
@@ -3,7 +3,7 @@ class FeedTimesController < ApplicationController
   before_action :find_feed_time, except: [:create]
 
   def create
-    time = valid_params[:time].to_time.utc
+    time = parse_time(valid_params[:time])
     feed_time = @pet_feeder.feed_times.new(time: time)
     if feed_time.save
       redirect_to settings_path


### PR DESCRIPTION
- a lot of discrepencies between how rails parses time locally
  versus how it happens on the server
- this method seems to attain desired results
