### PR TITLE
Reduced to 1 Puma worker

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,4 @@
-workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['MAX_THREADS'] || 5)
 threads threads_count, threads_count
 


### PR DESCRIPTION
- So clockwork is not triggered twice, once
  by each worker
